### PR TITLE
Sprint3 deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ public/system/dragonfly/*
 
 coverage/
 .vscode/
+public/assets*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /usr/src/app
 # Copy gems from a gem-cache build stage if specified, otherwise install them
 FROM base AS gems
 COPY --from=gem-cache /usr/local/bundle /usr/local/bundle
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile* ./
 # ensure we're using the correct platform
 
 RUN bundle config force_ruby_platform true  

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'jquery-rails'
 
 gem 'nokogiri', '~> 1.13.10'
 gem 'puma'
+gem 'racc', '~> 1.4', '>= 1.4.14'
 gem 'dotenv', '~> 2.8.1'
 
 gem 'bcrypt', '~> 3.1.7' 
@@ -34,7 +35,6 @@ group :test do
   gem 'simplecov', require: false
   gem 'cucumber-rails', require: false
   gem 'rspec-rails'
-  gem 'devise'
 end
 
 # for Heroku deployment - as described in Ap. A of ELLS book
@@ -49,10 +49,18 @@ group :development, :test do
   gem 'sqlite3', '~> 1.3.6'
 end
 
+gem 'connection_pool', '~> 2.4', '>= 2.4.1'
+
+group :production, :development do
+  gem 'rack-cache', '~> 1.14'
+
+  gem 'dalli', '~> 3.2', '>= 3.2.6'
+  gem "memcachier"            # sets enviroment variables prefixed with MEMCACHIER_* 
+
+end
+
 group :production do
   gem 'pg', '~> 0.15'
   gem 'rails_12factor'
   gem 'dragonfly-s3_data_store'
-  gem 'rack-cache', :require => 'rack/cache'
-
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,11 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     arel (6.0.4)
-    autoprefixer-rails (10.4.15.0)
+    autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
     base64 (0.2.0)
-    bcrypt (3.1.19)
-    bigdecimal (1.4.1)
+    bcrypt (3.1.20)
+    bigdecimal (1.4.4)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.1)
@@ -61,6 +61,7 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     cucumber (4.1.0)
       builder (~> 3.2, >= 3.2.3)
@@ -99,15 +100,10 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
+    dalli (3.2.6)
     database_cleaner (1.99.0)
-    date (3.3.3)
+    date (3.3.4)
     debug_inspector (1.1.0)
-    devise (4.9.3)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.4.0)
     dotenv (2.8.1)
@@ -119,7 +115,7 @@ GEM
       dragonfly (~> 1.0)
       fog-aws
     erubis (2.7.0)
-    excon (0.104.0)
+    excon (0.105.0)
     execjs (2.9.1)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -160,7 +156,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (2.7.1)
-    loofah (2.21.4)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -169,6 +165,7 @@ GEM
       net-pop
       net-smtp
     matrix (0.4.2)
+    memcachier (0.0.2)
     method_source (1.0.0)
     middleware (0.1.0)
     mime-types (3.5.1)
@@ -185,11 +182,11 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -213,7 +210,6 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    orm_adapter (0.5.0)
     pg (0.21.0)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
@@ -226,10 +222,10 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (1.6.13)
     rack-cache (1.14.0)
       rack (>= 0.4)
@@ -270,11 +266,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     remotipart (1.4.4)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -328,14 +321,12 @@ GEM
     thor (1.3.0)
     thread_safe (0.3.6)
     tilt (2.3.0)
-    timeout (0.4.0)
+    timeout (0.4.1)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     version_gem (1.1.3)
-    warden (1.2.7)
-      rack (>= 1.0)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -352,15 +343,17 @@ DEPENDENCIES
   bigdecimal (~> 1.4)
   bootstrap-sass
   byebug
+  connection_pool (~> 2.4, >= 2.4.1)
   cucumber-rails
+  dalli (~> 3.2, >= 3.2.6)
   database_cleaner
-  devise
   dotenv (~> 2.8.1)
   dragonfly (~> 1.4.0)
   dragonfly-s3_data_store
   factory_bot_rails
   faker
   jquery-rails
+  memcachier
   nokogiri (~> 1.13.10)
   omniauth-github (~> 2.0.0)
   omniauth-rails_csrf_protection
@@ -368,7 +361,8 @@ DEPENDENCIES
   pry
   pry-byebug
   puma
-  rack-cache
+  racc (~> 1.4, >= 1.4.14)
+  rack-cache (~> 1.14)
   rails (= 4.2.11)
   rails_12factor
   remotipart (~> 1.2)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -72,9 +72,11 @@ class Product < ApplicationRecord
             if img.valid?
                 self.images << img
             else
+                puts "#{img.errors.full_messages}}"
                 return false
             end
         end
+
         return true
     end
     

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -34,10 +34,6 @@
         <label class="form-check-label" for="flexSwitchCheckDefault" id="switchLabel">Card View</label>
     </div>
     <div class="product-list">
-        <%= render @products %>
+      <%= render partial: 'products/product', collection: @products, cached: true %>
     </div>
-</div>
-
-<div class="footer-wrapper">
-    <% # Will contain the code to display the footer%>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -13,7 +13,7 @@
 <h1>Photos</h1>
 <% if @product.images.present? %>
   <ul class="row" id="photos-list">
-    <%= render @product.images %>
+    <%= render partial: 'images/image', collection: @product.images, cached: true %>  
   </ul>
 <%end%>
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
-
 require ::File.expand_path('../config/environment', __FILE__)
+
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module App
     
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Configuation of Rack::Cache
+    config.cache_store = :mem_cache_store
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,6 @@ default: &default
 
 development:
   <<: *default
-  adapter: sqlite3
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
@@ -20,8 +19,5 @@ test:
 
 # Postgres production database
 production:
+  <<: *default 
   adapter: postgresql
-  database: <%= ENV['POSTGRES_DB'] %>
-  host: <%= ENV['POSTGRES_HOST'] || 'localhost'%>
-  username: <%= ENV['POSTGRES_USER'] %>
-  password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,9 @@ test:
   database: db/test.sqlite3
 
 # Postgres production database
-production:   
-  <<: *default
-  adapter: sqlite3
-  database: db/production.sqlite3
+production:
+  adapter: postgresql
+  database: <%= ENV['POSTGRES_DB'] %>
+  host: <%= ENV['POSTGRES_HOST'] || 'localhost'%>
+  username: <%= ENV['POSTGRES_USER'] %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,14 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  if ENV['ENABLE_CACHING'].present? 
+    config.action_controller.perform_caching = true
+    config.cache_store = :memory_store, { size: 64.megabytes }
+  else 
+    config.action_controller.perform_caching = false
+    config.cache_store = :null_store
+  end
+  
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -25,7 +32,8 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
+  config.assets.compile = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,81 +1,39 @@
-require 'pg' if Rails.env.production?
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Code is not reloaded between requests.
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
   config.cache_classes = true
 
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  # Do not eager load code on boot.
+  config.eager_load = false
 
-  # Full error reports are disabled and caching is turned on.
+  # Show full error reports and disable caching.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  config.action_dispatch.rack_cache = true
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
-
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-   # config.assets.css_compressor = :sass
-   
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+  
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = false
   config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,9 +27,9 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+   # config.assets.css_compressor = :sass
+   
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,7 +9,5 @@ Rails.application.config.assets.version = 'v1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-require 'dotenv'
-Dotenv.load
 
 

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -13,9 +13,11 @@ Dragonfly.app.configure do
       root_path: Rails.root.join('public/system/dragonfly', Rails.env),
       server_root: Rails.root.join('public')
   else
-    datastore :file,
-      root_path: Rails.root.join('public/system/dragonfly', Rails.env),
-      server_root: Rails.root.join('public')
+    datastore :s3,
+      bucket_name: ENV['S3_BUCKET_NAME'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: ENV['AWS_REGION'] || 'us-east-2'
   end
 end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,6 @@
 
 Rails.application.config.session_store :cookie_store, key: '_app_session'
 
-puts "Got to session_store.rb"
+# Rails.application.config.session_store ActionDispatch::Session::CacheStore, :expire_after => 20.minutes
+
+puts "Session store initialized"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
 
   resources :signup, only: %i[new create]
   resources :sessions, only: %i[new create]
-  
-  root :to => redirect('/products')
+
+  root 'products#index'
 
   # cart routes
   post '/cart/:product_id', to: 'carts#add', as: 'add_to_cart'


### PR DESCRIPTION
After recreating the production settings on my local branch. I found that the reason for the issue we encountered on the last deployment was because we had caching enabled, but not configured. This meant that when RakeCache was trying to retrieve static assets(CSS, and JS) would be nil. (at least thats how I'm interpreting this bug).  The solution was to configure our caching to connect to a memcached server (a server proxy thats available for free on Heroku). 

Nothing changes on the development end because we don't do any HTTP caching, but we can add it if we want to. 

Deployment is also finally streamlined.... All it took was setting the heroku stack to heroku:20 instead of using the heroku container registry. Deployments now take under 1 minute. 